### PR TITLE
Send CORS headers in case of an OPTIONS request only

### DIFF
--- a/CorsSlim.php
+++ b/CorsSlim.php
@@ -85,9 +85,10 @@ class CorsSlim extends \Slim\Middleware {
     }
 
     public function call() {
-        $this->setCorsHeaders($this->app);
-        if(!$this->app->request->isOptions()) {
-            $this->next->call();
+        if($this->app->request->isOptions()) {
+        	$this->setCorsHeaders($this->app);
+	} else {
+        	$this->next->call();
         }
     }
 }


### PR DESCRIPTION
Don't need to send CORS headers if it's not an OPTIONS request. The headers must be set for OPTIONS requests only.
