### PR TITLE
Add support for multiple origins by using an array for the origin setting.

### DIFF
--- a/CorsSlim.php
+++ b/CorsSlim.php
@@ -20,6 +20,24 @@ class CorsSlim extends \Slim\Middleware {
                                     $req->headers->get("Origin")
                                     );
         }
+
+	    // handle multiple allowed origins
+	    if(is_array($origin)) {
+
+		    $allowedOrigins = $origin;
+
+		    // default to the first allowed origin
+		    $origin = reset($allowedOrigins);
+
+		    // but use a specific origin if there is a match
+		    foreach($allowedOrigins as $allowedOrigin) {
+			    if($allowedOrigin === $req->headers->get("Origin")) {
+				    $origin = $allowedOrigin;
+				    break;
+			    }
+		    }
+	    }
+
         $rsp->headers->set('Access-Control-Allow-Origin', $origin);
     }
 


### PR DESCRIPTION
Add support for multiple origins if an array is passed in for the 'origin' setting. This works by returning the first value to match the actual origin of the request, or defaulting to the first value in the array.
